### PR TITLE
update readme installation instructions with correct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can find the full documentation for GC Design System Utility on [https://des
 Place the following code in the `<head>` element of your site.
 ```
 <!-- GC Design System Utility -->
-<link rel="stylesheet" href="https://unpkg.com/gcds-utility/dist/utilities.min.css">
+<link rel="stylesheet" href="https://unpkg.com/@cdssnc/gcds-utility/dist/utilities.min.css">
 ```
 <br/>
 
@@ -76,7 +76,7 @@ Toute la documentation sur l'utilitaire de Système de design GC est accessible 
 Inscrivez le code suivant dans l'élément `<head>` de votre site Web :
 ```
 <!-- GC Design System Utility -->
-<link rel="stylesheet" href="https://unpkg.com/gcds-utility/dist/utilities.min.css">
+<link rel="stylesheet" href="https://unpkg.com/@cdssnc/gcds-utility/dist/utilities.min.css">
 ```
 <br/>
 


### PR DESCRIPTION
# Summary | Résumé

Update readme installation instructions with the correct link - the link was still pointing to the unpkg link from before we moved the repo over to CDS.
