### PR TITLE
feat: publish new packages to CDN

### DIFF
--- a/.github/workflows/compile-core.yml
+++ b/.github/workflows/compile-core.yml
@@ -6,6 +6,15 @@ on:
     paths:
       - 'src/**'
 
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  CDN_BUCKET: gc-design-system-production-cdn
+  CDN_REGION: ca-central-1
+  PACKAGE_NAME: "@cdssnc/gcds-utility" 
+
 jobs:
   build-deploy:
     name: Compile Core
@@ -13,8 +22,10 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
       - name: Install
         run: npm install
+
       - name: Compile + Commit
         run: |
           gulp compile
@@ -22,8 +33,28 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add -A
           git commit -m "Compile utilities"
+
       - name: Push changes
         uses: ad-m/github-push-action@0fafdd62b84042d49ec0cb92d9cac7f7ce4ec79e
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: 'main'
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        with:
+          role-to-assume: arn:aws:iam::307395567143:role/gcds-components-apply
+          role-session-name: CDNPublish
+          aws-region: ${{ env.CDN_REGION }}
+
+      - name: Update CDN
+        run: |
+          VERSION="$(cat package.json | jq -r .version)"
+          PUBLISHED_PACKAGE="${{ env.PACKAGE_NAME }}@$VERSION"
+
+          aws s3 sync ./dist s3://${{ env.CDN_BUCKET }}/"$PUBLISHED_PACKAGE"/dist --delete
+          aws s3 sync ./dist s3://${{ env.CDN_BUCKET }}/${{ env.PACKAGE_NAME }}@latest/dist --delete
+          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key "$PUBLISHED_PACKAGE"/dist/gcds-utility.css
+          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key ${{ env.PACKAGE_NAME }}@latest/dist/gcds-utility.css
+
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"


### PR DESCRIPTION
# Summary
Update the publish package workflow so that new packages are now also published to the CDN.

Each new package will be published to a versioned directory in the CDN and replace the files for its @latest version. This will allow users to either link to versioned assets or the latest files.

# Related
- cds-snc/gcds-components#168
- cds-snc/platform-core-services#322