### PR TITLE
fix: use the correct OIDC role for the repo

### DIFF
--- a/.github/workflows/compile-core.yml
+++ b/.github/workflows/compile-core.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         with:
-          role-to-assume: arn:aws:iam::307395567143:role/gcds-components-apply
+          role-to-assume: arn:aws:iam::307395567143:role/gcds-utility-apply
           role-session-name: CDNPublish
           aws-region: ${{ env.CDN_REGION }}
 


### PR DESCRIPTION
# Summary
Update the IAM role used to publish changes to the CDN.

# Related
- cds-snc/platform-core-services#322