### PR TITLE
chore: update renovate template

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "extends": ["local>cds-snc/renovate-config"],
   "lockFileMaintenance": {
     "schedule": ["before 6am on the first day of the month"]
+  },
+  "changelog": {
+    "template": "{{version}}\n\nReleased on: {{date}}"
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Update renovate template to display:

```
<version>

Released on: <date>
```

Instead of:

`<version> <date>`