### PR TITLE
chore: remove changelog template from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,5 @@
   "extends": ["local>cds-snc/renovate-config"],
   "lockFileMaintenance": {
     "schedule": ["before 6am on the first day of the month"]
-  },
-  "changelog": {
-    "template": "{{version}}\n\nReleased on: {{date}}"
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Removing the changelog template from the renovate config to fix [this issue](https://github.com/cds-snc/gcds-utility/issues/194). The changelog template didn't end up working anyways so we are not losing anything :D 