### PR TITLE
revert: update google-github-actions/release-please-action action to v4

### DIFF
--- a/.github/workflows/release_generator.yml
+++ b/.github/workflows/release_generator.yml
@@ -19,7 +19,7 @@ jobs:
           app_id: ${{ secrets.SRE_APP_ID }}
           private_key: ${{ secrets.SRE_APP_PRIVATE_KEY }}
 
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
+      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3.7.13
         with:
           command: manifest
           token: ${{ steps.sre_app_token.outputs.token }}


### PR DESCRIPTION
Reverts cds-snc/gcds-utility#205

We need to modify the configuration if we're [changing from v3 to v4](https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#upgrading-from-v3-to-v4)