### PR TITLE
chore: update gulp-autoprefixer dependency, replace required statements with import/export syntax

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,15 @@
-const { dest, series, src, watch } = require('gulp');
-const minify = require('gulp-clean-css');
-const prefix = require('gulp-autoprefixer');
-const rename = require('gulp-rename');
-const sass = require('gulp-sass')(require('sass'));
+import { dest, series, src, watch } from 'gulp';
+import minify from 'gulp-clean-css';
+import prefix from 'gulp-autoprefixer';
+import rename from 'gulp-rename';
+import gulpSass from 'gulp-sass';
+import sassLib from 'sass';
+
+// Use `sassLib` (default export from `sass`) in `gulp-sass`
+const sass = gulpSass(sassLib);
 
 // Compile + prefix SCSS
-function compileAndPrefix() {
+export function compileAndPrefix() {
   return src('src/gcds-utility.scss')
     .pipe(sass())
     .pipe(prefix('last 2 versions'))
@@ -13,7 +17,7 @@ function compileAndPrefix() {
 }
 
 // Minify CSS
-function minifyCss() {
+export function minifyCss() {
   return src('dist/gcds-utility.css')
     .pipe(minify())
     .pipe(rename('gcds-utility.min.css'))
@@ -21,15 +25,15 @@ function minifyCss() {
 }
 
 // Watch SCSS for changes
-function watchTask() {
+export function watchTask() {
   watch(['src/*.scss', 'src/*/*.scss'], compileAndPrefix);
 }
 
 // Default gulp
-exports.default = series(compileAndPrefix, minifyCss, watchTask);
+export default series(compileAndPrefix, minifyCss, watchTask);
 
 // Compile
-exports.compile = series(compileAndPrefix, minifyCss);
+export const compile = series(compileAndPrefix, minifyCss);
 
 // Test
-exports.test = series(compileAndPrefix, minifyCss);
+export const test = series(compileAndPrefix, minifyCss);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@cdssnc/gcds-tokens": "^2.0.3",
         "gulp": "^5.0.0",
-        "gulp-autoprefixer": "^8.0.0",
+        "gulp-autoprefixer": "^9.0.0",
         "gulp-clean-css": "^4.3.0",
         "gulp-rename": "^2.0.0",
         "gulp-sass": "^6.0.0",
@@ -358,6 +358,31 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@types/expect": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
+      "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/vinyl": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.12.tgz",
+      "integrity": "sha512-Sr2fYMBUVGYq8kj3UthXFAu5UN6ZW+rYr4NACjZQJvHvj+c8lYv0CahmZ2P/r7iUkN44gGUBwqxZkrKXYPb7cw==",
+      "dev": true,
+      "dependencies": {
+        "@types/expect": "^1.20.4",
+        "@types/node": "*"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
@@ -366,19 +391,6 @@
       "license": "MIT",
       "dependencies": {
         "ansi-wrap": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ansi-gray": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-      "integrity": "sha512-HrgGIZUl8h2EHuZaU9hTR/cU5nhKxpVE1V6kdGsQ8e4zirElJ5fvtfc8N7Q1oq1aatO275i8pUFUCpNWCAnVWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-wrap": "0.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -822,16 +834,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -889,6 +891,18 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/easy-transform-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/easy-transform-stream/-/easy-transform-stream-1.0.1.tgz",
+      "integrity": "sha512-ktkaa6XR7COAR3oj02CF3IOgz2m1hCaY3SfzvKT4Svt2MhHw9XCt+ncJNWfe2TGz31iqzNGZ8spdKQflj+Rlog==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -957,22 +971,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fancy-log": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
-      "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "parse-node-version": "^1.0.0",
-        "time-stamp": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/fast-fifo": {
@@ -1286,21 +1284,21 @@
       }
     },
     "node_modules/gulp-autoprefixer": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-8.0.0.tgz",
-      "integrity": "sha512-sVR++PIaXpa81p52dmmA/jt50bw0egmylK5mjagfgOJ8uLDGaF9tHyzvetkY9Uo0gBZUS5sVqN3kX/GlUKOyog==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-9.0.0.tgz",
+      "integrity": "sha512-lVQz5fqdjm4RMB1O3xLPtaZNMbFFoGKbV+SN3NJgT9X+PIyYld7dXARpoXIKEZAqE9WC2SoDQU0mxqZahWq07A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "autoprefixer": "^10.2.6",
-        "fancy-log": "^1.3.3",
-        "plugin-error": "^1.0.1",
-        "postcss": "^8.3.0",
-        "through2": "^4.0.2",
+        "autoprefixer": "^10.4.16",
+        "gulp-plugin-extras": "^0.2.2",
+        "postcss": "^8.4.31",
         "vinyl-sourcemaps-apply": "^0.2.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       },
       "peerDependencies": {
         "gulp": ">=4"
@@ -1359,6 +1357,35 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/gulp-plugin-extras": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/gulp-plugin-extras/-/gulp-plugin-extras-0.2.2.tgz",
+      "integrity": "sha512-0gssXzTNrrOocYBWN4qOZqd03cz3bxhjxVUPZV9iJdBR0ZZbwMQO/OT8hZChYoc9GjKaA5meaqDr6CjkmKA7BA==",
+      "dev": true,
+      "dependencies": {
+        "@types/vinyl": "^2.0.9",
+        "chalk": "^5.3.0",
+        "easy-transform-stream": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gulp-plugin-extras/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/gulp-rename": {
@@ -1899,16 +1926,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/parse-node-version": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -2424,26 +2441,6 @@
         "b4a": "^1.6.4"
       }
     },
-    "node_modules/through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "3"
-      }
-    },
-    "node_modules/time-stamp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha512-gLCeArryy2yNTRzTGKbZbloctj64jkZ57hj5zdraXue6aFgd6PmvVtEyiUU+hvU0v7q08oVv8r8ev0tRo6bvgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2505,6 +2502,12 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Government of Canada | Gouvernement du Canada",
   "description": "GC Design System Utility",
   "homepage": "https://design-system.alpha.canada.ca/",
+  "type": "module",
   "files": [
     "dist/"
   ],
@@ -22,7 +23,7 @@
   "devDependencies": {
     "@cdssnc/gcds-tokens": "^2.0.3",
     "gulp": "^5.0.0",
-    "gulp-autoprefixer": "^8.0.0",
+    "gulp-autoprefixer": "^9.0.0",
     "gulp-clean-css": "^4.3.0",
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^6.0.0",


### PR DESCRIPTION
# Summary | Résumé

Update gulp-autoprefixer dependency to its latest version. As part of that version change, the `require` statements needed to be replaced with `import`/`export` syntax.

Replaces [this Renovate PR](https://github.com/cds-snc/gcds-utility/pull/203).