### PR TITLE
chore: fix publish workflow name for cdn upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish utility framework
 on:
   workflow_dispatch:
   push:
@@ -22,7 +22,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
-      - name: Publish @cdssnc/gcds-utility
+      - name: Publish @cdssnc/gcds-utility to npm
         uses: JS-DevTools/npm-publish@e06fe3ef65499b38eb12224f2a60979f6d797330
         id: publish
         with:


### PR DESCRIPTION
# Summary | Résumé

When separating the "Publish" and "Upload CDN" workflow last week, I missed updating the publish name in one spot. Fixing it in this PR to correctly trigger the Upload CDN workflow.
